### PR TITLE
Remove eta key from progress bar

### DIFF
--- a/cli/src/download.rs
+++ b/cli/src/download.rs
@@ -80,7 +80,6 @@ fn download_url(
             ProgressStyle::with_template(
                 "{prefix} [{elapsed_precise}] [{bar:.cyan/blue}] {bytes}/{total_bytes} {wide_msg:>}",
             )?
-            .with_key("eta", |state| format!("{:.1}s", state.eta().as_secs_f64()))
             .progress_chars("#>-"),
         );
         progress_bar.set_prefix(format!(


### PR DESCRIPTION
# Description

Context: https://github.com/gadomski/stac-incubator-rs/issues/4

I have little to no experience with `indicatif`, so I'm sorry if this isn't what we should do! I tried to fix the line as is, and still add the key, but couldn't figure out exactly what annotation I needed, so just opted for deleting it. I also couldn't really understand what the addition of the key did.

My attempt updating the bounds is below

```
❯ cargo build
   Compiling stac-cli v0.0.1 (/home/brendon/Dev/stac-incubator-rs/cli)
error[E0593]: closure is expected to take 2 arguments, but it takes 1 argument
   --> cli/src/download.rs:83:14
    |
83  |             .with_key("eta", |state : ProgressState| format!("{:.1}s", state.eta().as_secs_f64()))
    |              ^^^^^^^^        ----------------------- takes 1 argument
    |              |
    |              expected closure that takes 2 arguments
    |
    = note: required because of the requirements on the impl of `ProgressTracker` for `[closure@cli/src/download.rs:83:30: 83:98]`
note: required by a bound in `ProgressStyle::with_key`
   --> /home/brendon/.cargo/registry/src/github.com-1ecc6299db9ec823/indicatif-0.17.1/src/style.rs:150:24
    |
150 |     pub fn with_key<S: ProgressTracker + 'static>(
    |                        ^^^^^^^^^^^^^^^ required by this bound in `ProgressStyle::with_key`

For more information about this error, try `rustc --explain E0593`.
error: could not compile `stac-cli` due to previous error

``` 

# Test Plan

It didn't compile before, and now it does! That being said, I'm not sure if I removed functionality that is wanted. :upside_down_face: 